### PR TITLE
Handle errors from content script in analysis

### DIFF
--- a/sidepanel/components/analysis.js
+++ b/sidepanel/components/analysis.js
@@ -46,9 +46,17 @@ export class AnalysisComponent {
       }
       
       // Agora sim enviar a mensagem
-      const response = await chrome.tabs.sendMessage(tab.id, { action: "analyzePage" });
-      
-      if (!response || !response.analysis) {
+      const response = await chrome.tabs.sendMessage(tab.id, {
+        action: "analyzePage",
+      });
+
+      if (!response) {
+        throw new Error("Nenhuma resposta do content script");
+      }
+      if (response.error) {
+        throw new Error(response.error);
+      }
+      if (!response.analysis) {
         throw new Error("Não foi possível analisar a página");
       }
       


### PR DESCRIPTION
## Summary
- handle errors returned from content script when analyzing the page

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683f98ce58908330b6f4e5b87a19e1a2