### PR TITLE
Handle errors from content script in analysis

### DIFF
--- a/content/page-analyzer.js
+++ b/content/page-analyzer.js
@@ -326,10 +326,30 @@ function getElementPosition(element) {
  * Função auxiliar para gerar seletor CSS
  */
 function getSelector(element) {
-  if (element.id) return `#${element.id}`;
-  if (element.className) {
-    const classes = element.className.split(' ').filter(c => c.trim());
-    if (classes.length) return `.${classes[0]}`;
+  if (element.id) {
+    return `#${element.id}`;
   }
+
+  let className = "";
+
+  if (typeof element.className === "string") {
+    className = element.className;
+  } else if (
+    typeof element.className === "object" &&
+    element.className.baseVal
+  ) {
+    // Suporte para elementos SVG onde className é um SVGAnimatedString
+    className = element.className.baseVal;
+  } else if (element.getAttribute) {
+    className = element.getAttribute("class") || "";
+  }
+
+  if (className) {
+    const classes = className.split(" ").filter((c) => c.trim());
+    if (classes.length) {
+      return `.${classes[0]}`;
+    }
+  }
+
   return element.tagName.toLowerCase();
-} 
+}

--- a/sidepanel/components/analysis.js
+++ b/sidepanel/components/analysis.js
@@ -46,9 +46,17 @@ export class AnalysisComponent {
       }
       
       // Agora sim enviar a mensagem
-      const response = await chrome.tabs.sendMessage(tab.id, { action: "analyzePage" });
-      
-      if (!response || !response.analysis) {
+      const response = await chrome.tabs.sendMessage(tab.id, {
+        action: "analyzePage",
+      });
+
+      if (!response) {
+        throw new Error("Nenhuma resposta do content script");
+      }
+      if (response.error) {
+        throw new Error(response.error);
+      }
+      if (!response.analysis) {
         throw new Error("Não foi possível analisar a página");
       }
       


### PR DESCRIPTION
## Summary
- handle errors returned from content script when analyzing the page
- support SVG elements in page analyzer

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683f98ce58908330b6f4e5b87a19e1a2